### PR TITLE
Add order queue and associated configuration

### DIFF
--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -48,4 +48,6 @@ module appService 'modules/appService.bicep' = {
   }
 }
 
+// I need to make a change
+
 output appServiceAppHostName string = appService.outputs.appServiceAppHostName


### PR DESCRIPTION
This PR adds a new Azure Storage queue for processing orders, and updates the website configuration to include the storage account and queue information.